### PR TITLE
AT 17.05 | Page-header > Logout btn > Log out button transfer the user back to the login page 'Welcome to Jenkins!'

### DIFF
--- a/src/test/java/school/redrover/HeaderTest.java
+++ b/src/test/java/school/redrover/HeaderTest.java
@@ -166,4 +166,14 @@ public class HeaderTest extends BaseTest {
         Assert.assertTrue(getWait5().until(ExpectedConditions.textToBe
                 (By.xpath("//div[@class='jenkins-app-bar__content']/h1"), "Built-In Node")));
     }
+
+    @Test
+    public void testLogOutButtonTransfersBackToLoginPaged() {
+        final String expectedHeader = "Welcome to Jenkins!";
+
+        getDriver().findElement(By.xpath("//a[@href='/logout']")).click();
+        WebElement actualHeader = getDriver().findElement(By.xpath("//h1"));
+
+        Assert.assertEquals(actualHeader.getText(), expectedHeader);
+    }
 }


### PR DESCRIPTION
AT - https://trello.com/c/lCnBLJOQ/556-at-1705-page-header-logout-btn-log-out-button-transfer-the-user-back-to-the-login-page-welcome-to-jenkins

TC - https://trello.com/c/8gA5oJfI/555-tc-1705-page-header-logout-btn-log-out-button-transfer-the-user-back-to-the-login-page-welcome-to-jenkins