### PR TITLE
RF 09.02 | Manage Jenkins > Search settings > Search with numeric symbol

### DIFF
--- a/src/test/java/school/redrover/FreestyleProject5Test.java
+++ b/src/test/java/school/redrover/FreestyleProject5Test.java
@@ -28,7 +28,7 @@ public class FreestyleProject5Test extends BaseTest {
 
     @Test
     public void testDisableFreestyleProject(){
-        TestUtils.createFreestyleProject(this, "First Freestyle Project");
+        TestUtils.createFreestyleProject(this, "First Freestyle Project", true);
 
         getDriver().findElement(By.xpath("//a[@class='jenkins-table__link model-link inside']/span")).click();
         getDriver().findElement(By.xpath("//form[@id='disable-project']/button")).click();

--- a/src/test/java/school/redrover/ManageJenkinsTest.java
+++ b/src/test/java/school/redrover/ManageJenkinsTest.java
@@ -109,7 +109,7 @@ public class ManageJenkinsTest extends BaseTest {
         getDriver().findElement(By.xpath("//a[@href='/manage']")).click();
         getWait2().until(ExpectedConditions.presenceOfElementLocated(By.id("settings-search-bar")));
         getDriver().findElement(By.id("settings-search-bar")).sendKeys("1");
-        getWait10().until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[contains(@class, 'results-container--visible')][@style='height: 98px;']")));
+        getWait5().until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[contains(@class, 'results-container--visible')][@style='height: 98px;']")));
         WebElement noResults = getDriver().findElement(By.cssSelector(".jenkins-search__results__no-results-label"));
 
         Assert.assertEquals(noResults.getText(), "No results");

--- a/src/test/java/school/redrover/ManageJenkinsTest.java
+++ b/src/test/java/school/redrover/ManageJenkinsTest.java
@@ -5,7 +5,6 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
-import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 import school.redrover.runner.BaseTest;
 
@@ -104,15 +103,13 @@ public class ManageJenkinsTest extends BaseTest {
         Assert.assertTrue(getDriver().findElement(By.id("main-panel")).getText().contains("No old data was found."));
     }
 
-    @Ignore
+
     @Test
     public void testSearchNumericSymbol() {
         getDriver().findElement(By.xpath("//a[@href='/manage']")).click();
         getWait2().until(ExpectedConditions.presenceOfElementLocated(By.id("settings-search-bar")));
         getDriver().findElement(By.id("settings-search-bar")).sendKeys("1");
-        WebElement visibleElement = getDriver().findElement(By.cssSelector(".jenkins-search__results-container--visible"));
-        String valueOuterHTMLOfvisibleElement = visibleElement.getAttribute("outerHTML");
-        getWait2().until(ExpectedConditions.domPropertyToBe(visibleElement,"outerHTML", valueOuterHTMLOfvisibleElement));
+        getWait2().until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[contains(@class, 'results-container--visible')][@style='height: 98px;']")));
         WebElement noResults = getDriver().findElement(By.cssSelector(".jenkins-search__results__no-results-label"));
 
         Assert.assertEquals(noResults.getText(), "No results");

--- a/src/test/java/school/redrover/ManageJenkinsTest.java
+++ b/src/test/java/school/redrover/ManageJenkinsTest.java
@@ -109,7 +109,7 @@ public class ManageJenkinsTest extends BaseTest {
         getDriver().findElement(By.xpath("//a[@href='/manage']")).click();
         getWait2().until(ExpectedConditions.presenceOfElementLocated(By.id("settings-search-bar")));
         getDriver().findElement(By.id("settings-search-bar")).sendKeys("1");
-        getWait5().until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[contains(@class, 'results-container--visible')][@style='height: 98px;']")));
+        getWait10().until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[contains(@class, 'results-container--visible')][@style='height: 98px;']")));
         WebElement noResults = getDriver().findElement(By.cssSelector(".jenkins-search__results__no-results-label"));
 
         Assert.assertEquals(noResults.getText(), "No results");

--- a/src/test/java/school/redrover/ManageJenkinsTest.java
+++ b/src/test/java/school/redrover/ManageJenkinsTest.java
@@ -109,7 +109,7 @@ public class ManageJenkinsTest extends BaseTest {
         getDriver().findElement(By.xpath("//a[@href='/manage']")).click();
         getWait2().until(ExpectedConditions.presenceOfElementLocated(By.id("settings-search-bar")));
         getDriver().findElement(By.id("settings-search-bar")).sendKeys("1");
-        getWait2().until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[contains(@class, 'results-container--visible')][@style='height: 98px;']")));
+        getWait10().until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[contains(@class, 'results-container--visible')][@style='height: 98px;']")));
         WebElement noResults = getDriver().findElement(By.cssSelector(".jenkins-search__results__no-results-label"));
 
         Assert.assertEquals(noResults.getText(), "No results");


### PR DESCRIPTION
fix testDisableFreestyleProject() - add to TestUtils.createFreestyleProject() true,
fix testSearchNumericSymbol() - change xpath
[RF](https://trello.com/c/TdCFqeYl)