### PR TITLE
AT 17.04 | Page-header > User Profile Icon > Verify the admin button is underlines when mouseover

### DIFF
--- a/src/test/java/school/redrover/HeaderTest.java
+++ b/src/test/java/school/redrover/HeaderTest.java
@@ -331,4 +331,18 @@ public class HeaderTest extends BaseTest {
                 getWait2().until(ExpectedConditions.visibilityOfElementLocated(By.id("main-panel"))).isDisplayed());
     }
 
+    @Test
+    public void testAdminButtonIsUnderlinedWhenMouseover() {
+
+        Actions act = new Actions(getDriver());
+
+        WebElement adminLink = getWait5().until(ExpectedConditions.visibilityOfElementLocated(
+                By.xpath("//a[@class='model-link'][1]")));
+
+        act.moveToElement(adminLink).perform();
+
+        String textUnderlineAfter = adminLink.getCssValue("text-decoration");
+
+        Assert.assertTrue(textUnderlineAfter.contains("underline"));
+    }
 }


### PR DESCRIPTION
https://trello.com/c/6JoZLOzi/1098-at-1704-page-header-user-profile-icon-verify-the-admin-button-is-underlines-when-mouseover

added testAdminButtonIsUnderlinedWhenMouseover