### PR TITLE
RF | FreestyleProjectAllTest > testCreateFreestyleProjectWithValidData

### DIFF
--- a/src/test/java/school/redrover/FreestyleProjectAllTest.java
+++ b/src/test/java/school/redrover/FreestyleProjectAllTest.java
@@ -7,24 +7,25 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import school.redrover.runner.BaseTest;
 
-public class NewItemFreestyleProjectAllTest extends BaseTest {
+public class FreestyleProjectAllTest extends BaseTest {
+
     @Test
     public void testCreateFreestyleProjectWithValidData() {
         final String projectName = "My Freestyle Project";
 
         getDriver().findElement(By.xpath("//a[@href='/view/all/newJob']")).click();
 
-        getWait2().until(ExpectedConditions.elementToBeClickable(By.name("name"))).sendKeys(projectName);
+        getWait2().until(ExpectedConditions.visibilityOfElementLocated(By.name("name"))).sendKeys(projectName);
         getDriver().findElement(By.cssSelector(".icon-freestyle-project")).click();
 
-        getWait2().until(ExpectedConditions.elementToBeClickable(By.xpath("//button[@id='ok-button']"))).click();
+        getWait2().until(ExpectedConditions.elementToBeClickable(By.id("ok-button"))).click();
 
         getWait2().until(ExpectedConditions.elementToBeClickable(By.xpath("//button[@name='Submit']"))).click();
 
         getDriver().findElement(By.linkText("Dashboard")).click();
 
         String actualProjectNameOnDashboard = getWait10().until(ExpectedConditions
-                .visibilityOfElementLocated(By.xpath("//table[@id='projectstatus']/tbody/tr/td[3]/a/span")))
+                        .visibilityOfElementLocated(By.cssSelector(".jenkins-table__link.model-link.inside>span")))
                 .getText();
 
         Assert.assertEquals(actualProjectNameOnDashboard, projectName);


### PR DESCRIPTION
https://trello.com/c/5q36mcpX

The test class is renamed from NewItemFreestyleProjectAllTest to FreestyleProjectAllTest

The XPath of Freestyle Project name is changed from "//table[@id='projectstatus']/tbody/tr/td[3]/a/span" to CssSelector ".jenkins-table__link.model-link.inside>span" to make the test more stable

Expected condition is changed